### PR TITLE
Version lock p5.play


### DIFF
--- a/extravaganza ekranoplan/index.html
+++ b/extravaganza ekranoplan/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!--https://preview.c9users.io/maxwofford/pe5/index.html-->
+<html>
+  <head>
+    <title>pE5</title>
+    <link rel="stylesheet" href="styles.css" type="text/css">
+  </head>
+  <body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.12/p5.js"></script>
+    <script src="https://cdn.rawgit.com/molleindustria/p5.play/1bf3c72fe6b647617373b9b3ea3e419baaef8cfd/lib/p5.play.js"></script>
+    <script src="game.js"></script>
+    <h1>Extravaganza ekranoplan</h1>
+    <p>Collect 10 eggs! Use WASD, vim keys, or arrow keys to move around!</p>
+    <p id="demo"></p>
+    <p id="eggs"></p>
+    <!--https://i.imgur.com/oq2qkUN.gif-->
+    <iframe id='danger' display='none' height="0" width="0" src="//www.youtube.com/embed/siwpn14IE7E?t=59s&autoplay=1&loop=1&playlist=GRonxog5mbw" frameborder="0"></iframe>
+    <div id='danger'></div>
+    
+  </body>
+</html>


### PR DESCRIPTION
Hey! I'm one of the engineers at [Hack Club](https://hackclub.com). Right now your site is broken because it links to the most recent version of p5.play.js, but when that updates your site won't work. I made this edit to set p5.play.js to a specific version so it won't update automatically (and should always work with your site).

Just click the "Merge" button that looks like this down below if you want to accept the edit:

![](https://i.imgur.com/Vz3I4Oi.png)

_This PR is created by a script for people who have completed Hack Club's workshops. If you think it was sent to you in error go ahead and click "close"._
